### PR TITLE
Read PORT from env so chef can bind alongside multi-service stacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const fhir2fshRouter = require('./fhir2fsh')
 const app = express();
 app.use(express.json({ type: ['application/json', 'application/fhir+json'], limit: '1000mb'}));
 app.use(express.text({ type: ['application/fsh'], limit: '1000mb'}));
-const port = 3000;
+const port = parseInt(process.env.PORT, 10) || 3000;
 
 app.use(cors())
 app.use(fsh2fhirRouter)


### PR DESCRIPTION
## Summary

- Replace `const port = 3000` with `const port = parseInt(process.env.PORT, 10) || 3000` so the listen port is overridable.
- Default behavior is unchanged — bare `node index.js` still binds 3000.

## Why

Hardcoding 3000 forces every host that runs chef to either reserve that port or front it with a proxy. In our case, HelexEMR's port map has chef on **18415** (sibling of tx-backend on 18414), but we were forced to either patch chef downstream or reconfigure tx-backend to point at 3000. Reading `PORT` from env is the standard Node convention and unblocks any consumer that has a different port map.

## Test plan

- [x] `node index.js` → `Running on http://localhost:3000/` (unchanged default)
- [x] `PORT=18415 node index.js` → `Running on http://localhost:18415/`
- [x] `PORT=invalid node index.js` → falls back to 3000 (parseInt returns NaN, `||` defaults)